### PR TITLE
Adding Mac support

### DIFF
--- a/platforms/darwin.js
+++ b/platforms/darwin.js
@@ -1,5 +1,35 @@
-'use strict'
+"use strict";
 
-module.exports = cb => {
-	cb('Mac not yet supported')
-}
+const child_proc = require("child_process");
+
+const apple_script_code = `
+    # Check if Spotify is currently running
+    if application "Spotify" is running then
+        # If this executes it means Spotify is currently running
+        getCurrentlyPlayingTrack()
+    end if
+    on getCurrentlyPlayingTrack()
+        tell application "Spotify"
+            set isPlaying to player state as string
+            set currentArtist to artist of current track as string
+            set currentTrack to name of current track as string
+            return {currentArtist, currentTrack, isPlaying}
+        end tell
+    end getCurrentlyPlayingTrack`;
+
+module.exports = (cb) => {
+    const cmd = `osascript -e '${apple_script_code}'`;
+    child_proc.exec(cmd, (err, stdout) => {
+        // output looks like Song Name, Artist Name, (playing | paused)
+        if (!stdout) return cb("Cannot find Spotify process", err);
+
+        const res = stdout.split(",").map((x) => x.trim());
+        let output;
+        if (res[2].toLowerCase() !== "playing") {
+            output = "Spotify";
+        } else {
+            output = `${res[0]} - ${res[1]}`;
+        }
+        cb(err, err || output);
+    });
+};


### PR DESCRIPTION
Hi,

I've tested this on my Mac on Monterey 12.3.1 and it seems to work fine. I got the script from [this Python library](https://github.com/SwagLyrics/SwSpotify/blob/master/SwSpotify/spotify.py) which I've used in the past (it might have some useful stuff for the other platforms too).

I've tried to stick with how the other platforms seemed to work so let me know if it looks okay 😄 

Linked with issue #1